### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. iOS, Windows]
+ - Browser: [e.g. chrome, safari]
+ - Version: [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**What is the feature you want to add?**
+A clear and concise description of the new feature or change (e.g. "Add a generic primary button component", "Setup Next.js project routing").
+
+**Why is it needed?**
+Briefly explain the purpose or use case for this feature.
+
+**Checklist (optional)**
+- [ ] Task 1
+- [ ] Task 2
+
+**Context / Screenshots (optional)**
+Add any other context, UI mockups, or screenshots if applicable.


### PR DESCRIPTION
bug report and feature request

## Description
Adding official GitHub Issue Templates for 'Bug Reports' and 'Feature Requests'.

Closes #6

## Does the code work?
- [X] Yes, it has been verified to run correctly.
- [ ] No / Needs further investigation.

## Has it been tested?
- [ ] Yes, automated tests have been added/updated.
- [ ] Yes, manual testing has been performed.
- [X] N/A

## How was AI used?
I used Gemini to generate the standard Markdown structure for the Bug Report and Feature Request templates, ensuring they follow GitHub's best practices for open-source projects

## Additional Comments
Once merged, the team can use the 'New Issue' button to see these templates in action.
